### PR TITLE
fix: Correct chick arrival cost calculation

### DIFF
--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -99,7 +99,7 @@ export const DataProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     const currentStock = totalChicks - totalMortality - totalSalesQuantity;
     const totalRevenue = sales.reduce((sum, sale) => sum + sale.amountReceived, 0);
     const totalOutstanding = sales.reduce((sum, sale) => sum + sale.outstandingBalance, 0);
-    const totalArrivalCost = chickArrivals.reduce((sum, arrival) => sum + ((arrival.price || 0) * (arrival.quantity || 0)), 0);
+    const totalArrivalCost = chickArrivals.reduce((sum, arrival) => sum + (arrival.price || 0), 0);
     const totalFeedCost = feedMedicines.filter(item => item.type === 'feed').reduce((sum, item) => sum + item.cost, 0);
     const totalMedicineCost = feedMedicines.filter(item => item.type === 'medicine').reduce((sum, item) => sum + item.cost, 0);
     const totalExtraExpenses = extraExpenses.reduce((sum, exp) => sum + exp.amount, 0);


### PR DESCRIPTION
The previous calculation for total chick arrival cost was incorrectly multiplying the price by the quantity. This assumed the price entered was per-chick, when it was intended to be the total cost for the batch.

This commit corrects the calculation in `DataContext.tsx` to use only the price field from the chick arrival data, without multiplying by quantity. This ensures the total expenses are calculated correctly based on the user's input.